### PR TITLE
時間割アプリの機能改善とバグ修正

### DIFF
--- a/src/components/HomeScreen.vue
+++ b/src/components/HomeScreen.vue
@@ -187,6 +187,16 @@ onMounted(async () => {
   weekRange.value = getCurrentWeekRange()
   weekDates.value = getWeekDates()
   
+  // データの整合性チェック・クリーンアップ
+  try {
+    const cleanedCount = await timetableService.cleanupDuplicateData()
+    if (cleanedCount > 0) {
+      console.log(`${cleanedCount}件の重複データを削除しました`)
+    }
+  } catch (error) {
+    console.error('データクリーンアップエラー:', error)
+  }
+  
   await addSampleData()
   await loadScheduleData()
 })


### PR DESCRIPTION
## 概要
このPRは時間割管理アプリの複数の機能改善とバグ修正を含んでいます。

## 主な変更内容

### 新機能・改善
- 動的な週表示機能: 現在の日付に基づいて週の日付を自動計算
- 曜日ヘッダーの拡張: 曜日名と日付を併記表示
- 時限表示の改善: 二段構成で時限と時間を見やすく表示

### バグ修正
- 予定削除時の復活問題を修正 (Fixes #25)
- 同一セルに複数の予定データが存在する問題を解決
- データベースサービスの重複データ処理を改善
- 自動データクリーンアップ機能を追加

## 技術的詳細
- getClassesByDayAndPeriod() メソッドを追加
- ID優先度による最新データ取得ロジックを実装
- addClass() で既存データの自動削除機能を追加
- cleanupDuplicateData() による重複データクリーンアップ機能を追加

## 関連Issue
- Fixes #25: 予定削除時に以前の予定が復活する問題