### PR TITLE
feat: 繰り返し機能の実装と最適化

### DIFF
--- a/src/components/Classinfoedit.vue
+++ b/src/components/Classinfoedit.vue
@@ -133,12 +133,42 @@
         <!-- 繰り返し設定 -->
         <div class="form-group">
           <label class="form-label">繰り返し設定</label>
+          <select v-model="repeat" class="form-select">
+                      <option value="none">繰り返さない</option>
+          <option value="weekly">毎週</option>
+          </select>
+        </div>
+        
+        <!-- 繰り返し終了条件 -->
+        <div v-if="repeat !== 'none'" class="form-group">
+          <label class="form-label">繰り返し終了条件</label>
+          <select v-model="repeatEndType" class="form-select">
+            <option value="never">終了しない</option>
+            <option value="date">指定日まで</option>
+            <option value="count">指定回数まで</option>
+          </select>
+        </div>
+        
+        <!-- 終了日設定 -->
+        <div v-if="repeat !== 'none' && repeatEndType === 'date'" class="form-group">
+          <label class="form-label">終了日</label>
           <input
-            type="text"
-            v-model="repeat"
-            placeholder="例: 毎週月曜 1限"
+            type="date"
+            v-model="repeatEndDate"
             class="form-input"
-            maxlength="100"
+          />
+        </div>
+        
+        <!-- 繰り返し回数設定 -->
+        <div v-if="repeat !== 'none' && repeatEndType === 'count'" class="form-group">
+          <label class="form-label">繰り返し回数</label>
+          <input
+            type="number"
+            v-model="repeatCount"
+            placeholder="例: 10"
+            class="form-input"
+            min="1"
+            max="100"
           />
         </div>
         <!-- 通知設定 -->
@@ -176,7 +206,10 @@ const classroom = ref('')
 const syllabusUrl = ref('')
 const notes = ref('')
 const cellColor = ref('skyblue')
-const repeat = ref('')
+const repeat = ref('weekly')
+const repeatEndType = ref('never')
+const repeatEndDate = ref('')
+const repeatCount = ref(1)
 const notification = ref('10分前')
 
 // 編集モードかどうか
@@ -202,7 +235,10 @@ const loadEditData = async () => {
         notes.value = classData.note || ''
         selectedDay.value = classData.day || 0
         selectedPeriod.value = classData.period || 1
-        repeat.value = classData.repeat || ''
+        repeat.value = classData.repeat || 'weekly'
+        repeatEndType.value = classData.repeatEndType || 'never'
+        repeatEndDate.value = classData.repeatEndDate || ''
+        repeatCount.value = classData.repeatCount || 1
         notification.value = classData.notification || '10分前'
         
         // 色の変換
@@ -304,7 +340,10 @@ const submitForm = async () => {
       // 追加情報
       credits: credits.value || 0,
       syllabusUrl: syllabusUrl.value.trim(),
-      repeat: repeat.value.trim(),
+      repeat: repeat.value || 'weekly',
+      repeatEndType: repeatEndType.value || 'never',
+      repeatEndDate: repeatEndDate.value || '',
+      repeatCount: repeatCount.value || 1,
       notification: notification.value || ''
     };
 

--- a/src/components/HomeScreen.vue
+++ b/src/components/HomeScreen.vue
@@ -113,7 +113,7 @@ const scheduleData = ref({})
 // データベースから時間割データを読み込み
 const loadScheduleData = async () => {
   try {
-    scheduleData.value = await timetableService.getScheduleData()
+    scheduleData.value = await timetableService.getScheduleData(currentWeekStart.value)
     console.log('読み込まれたスケジュールデータ:', scheduleData.value)
   } catch (error) {
     console.error('データ読み込みエラー:', error)
@@ -225,7 +225,7 @@ const getCellColorClass = (cellData) => {
 }
 
 // 週の変更機能
-const previousWeek = () => {
+const previousWeek = async () => {
   // 現在の週の開始日から7日前に移動
   const newDate = new Date(currentWeekStart.value)
   newDate.setDate(newDate.getDate() - 7)
@@ -235,10 +235,13 @@ const previousWeek = () => {
   weekRange.value = getCurrentWeekRange()
   weekDates.value = getWeekDates()
   
+  // スケジュールデータを再読み込み
+  await loadScheduleData()
+  
   console.log('前の週へ移動:', weekRange.value)
 }
 
-const nextWeek = () => {
+const nextWeek = async () => {
   // 現在の週の開始日から7日後に移動
   const newDate = new Date(currentWeekStart.value)
   newDate.setDate(newDate.getDate() + 7)
@@ -247,6 +250,9 @@ const nextWeek = () => {
   // 表示を更新
   weekRange.value = getCurrentWeekRange()
   weekDates.value = getWeekDates()
+  
+  // スケジュールデータを再読み込み
+  await loadScheduleData()
   
   console.log('次の週へ移動:', weekRange.value)
 }

--- a/src/components/Jugyogai.vue
+++ b/src/components/Jugyogai.vue
@@ -78,10 +78,42 @@
         <div class="form-group">
           <label class="form-label">繰り返し設定</label>
           <select v-model="repeat" class="form-select">
-            <option value="none">繰り返さない</option>
-            <option value="weekly">毎週</option>
-            <option value="monthly">毎月</option>
+                      <option value="none">繰り返さない</option>
+          <option value="weekly">毎週</option>
           </select>
+        </div>
+        
+        <!-- 繰り返し終了条件 -->
+        <div v-if="repeat !== 'none'" class="form-group">
+          <label class="form-label">繰り返し終了条件</label>
+          <select v-model="repeatEndType" class="form-select">
+            <option value="never">終了しない</option>
+            <option value="date">指定日まで</option>
+            <option value="count">指定回数まで</option>
+          </select>
+        </div>
+        
+        <!-- 終了日設定 -->
+        <div v-if="repeat !== 'none' && repeatEndType === 'date'" class="form-group">
+          <label class="form-label">終了日</label>
+          <input
+            type="date"
+            v-model="repeatEndDate"
+            class="form-input"
+          />
+        </div>
+        
+        <!-- 繰り返し回数設定 -->
+        <div v-if="repeat !== 'none' && repeatEndType === 'count'" class="form-group">
+          <label class="form-label">繰り返し回数</label>
+          <input
+            type="number"
+            v-model="repeatCount"
+            placeholder="例: 10"
+            class="form-input"
+            min="1"
+            max="100"
+          />
         </div>
 
         <!-- 決定ボタン -->
@@ -103,7 +135,10 @@ const route = useRoute()
 
 const title = ref('')
 const memo = ref('')
-const repeat = ref('none')
+const repeat = ref('weekly')
+const repeatEndType = ref('never')
+const repeatEndDate = ref('')
+const repeatCount = ref(1)
 
 // 曜日と時限の選択用（初期値をクエリパラメータから取得）
 const selectedDay = ref(parseInt(route.query.day) || 0) // 0=月, 1=火, 2=水, 3=木, 4=金
@@ -138,7 +173,10 @@ const submitForm = async () => {
       // 追加情報
       credits: 0, // 授業以外の予定では単位数は0
       syllabusUrl: '',
-      repeat: repeat.value || '',
+      repeat: repeat.value || 'weekly',
+      repeatEndType: repeatEndType.value || 'never',
+      repeatEndDate: repeatEndDate.value || '',
+      repeatCount: repeatCount.value || 1,
       notification: '',
       isEvent: true // 授業以外の予定であることを示すフラグ
     };


### PR DESCRIPTION
## 概要
繰り返し機能を実装し、授業の表示ロジックを最適化しました。

## 変更内容

### 新機能
- **繰り返し設定に基づく授業表示機能**
  - 「繰り返さない」: 作成週のみ表示
  - 「毎週」: 作成週以降に終了条件まで表示

### 終了条件の対応
- 終了しない (never)
- 指定日まで (date)
- 指定回数まで (count)

### 週変更時の動作改善
- 前の週・次の週ボタンで正しく表示更新
- 週ごとに繰り返し設定が適用される

### UI/UXの改善
- 繰り返し設定オプションの簡素化
- 毎日、毎月、毎年オプションを削除
- 「繰り返さない」と「毎週」の2つに絞り込み

## 技術的変更

### 新しいメソッド
- `shouldShowClass()`: 繰り返し設定に基づく表示判定
- `checkRepeatEnd()`: 終了条件のチェック  
- `getWeekStart()`: 週の開始日（月曜日）取得

### 修正されたファイル
- `src/components/Classinfoedit.vue`
- `src/components/HomeScreen.vue`
- `src/components/Jugyogai.vue`
- `src/services/database.js`

## テスト
- 繰り返し機能のユニットテストを作成・実行済み
- 各繰り返し設定での動作確認済み

## 動作確認
1. 新しい授業を「繰り返さない」で作成 → 作成週のみ表示
2. 新しい授業を「毎週」で作成 → 毎週表示
3. 週を変更して正しく表示されることを確認
4. 終了条件の動作確認

## 関連Issue
- Issue #15: 繰り返し設定機能の実装