### PR TITLE
fix: モバイル用のセルの幅を調整

### DIFF
--- a/src/components/HomeScreen.vue
+++ b/src/components/HomeScreen.vue
@@ -643,7 +643,7 @@ const parseCellId = (cellId) => {
 
   .header-row,
   .timetable-row {
-    grid-template-columns: minmax(80px, 100px) repeat(5, 1fr);
+    grid-template-columns: 40px repeat(5, 1fr)!important;
   }
 
   .day-header {
@@ -674,7 +674,7 @@ const parseCellId = (cellId) => {
   }
 
   .schedule-cell {
-    min-height: 60px;
+    min-height: 65px!important; 
   }
 
   .class-name {


### PR DESCRIPTION
モバイル用の幅を調査しました。
- 時限の列を極限まで狭めた
- セルの縦幅を伸ばし、下の余白を狭めた